### PR TITLE
Add AltoRank skill to Official vendor skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Built by the company whose data the skills use.
 | Repo | What it covers | Works with | Licence | Stars | Updated |
 | --- | --- | --- | --- | --- | --- |
 | [seranking/seo-skills](https://github.com/seranking/seo-skills) | Content briefs, AI search share of voice, audits, backlink gaps, keyword clusters, schema, sitemaps, GEO. Built for the SE Ranking MCP server, but every API call is documented so it can be adapted | Claude Code | MIT | 136 | 2026-06-25 |
+| [AltoRank/altorank](https://github.com/AltoRank/altorank/blob/main/apps/web/scripts/SKILL.md) | One skill for driving AltoRank from a coding agent: readiness audits, Search Console, keyword research, writing drafts into a human review queue, moving the content plan. Documents the HTTP, CLI and MCP surfaces, so the API calls can be adapted. No publish or approve call exists | Claude Code, any MCP client | AGPL-3.0 | 1 | 2026-09-07 |
 
 ## Large multi-skill packs
 


### PR DESCRIPTION
Adds the AltoRank skill to **Official vendor skills**, below the SE Ranking row (descending star order).

Against your three criteria:

1. **A real `SKILL.md`** — [`apps/web/scripts/SKILL.md`](https://github.com/AltoRank/altorank/blob/main/apps/web/scripts/SKILL.md), with frontmatter, not a prompt collection.
2. **Public and installable** — AGPL-3.0, clonable today, first tagged release v0.1.0.
3. **Does SEO work** — agent-readiness audits, Search Console, keyword research, drafting into a review queue, moving the content calendar, find-and-replace edits.

Three caveats, since your CONTRIBUTING asks for accuracy over marketing:

- **It is one skill, not a pack.** If the section is meant for multi-skill packs, say so and I will close it.
- **The account half needs an AltoRank API key**; the readiness tools do not. Same shape as the SE Ranking entry, which is built for their MCP server — the HTTP, CLI and MCP surfaces are all documented in the skill, so the calls can be adapted.
- **It is not an MCP-server submission.** AltoRank does ship one, and that went to [awesome-seo-mcp#1](https://github.com/RankSpotAI/awesome-seo-mcp/pull/1) separately, per your split. If you would rather have only one of the two, keep the MCP one.

I am the author. Happy to reword, move, or close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)